### PR TITLE
add missing test on toastActions in SW

### DIFF
--- a/scripts/service-worker-registration.js
+++ b/scripts/service-worker-registration.js
@@ -23,9 +23,11 @@
                 switch (installingWorker.state) {
                   case 'installed':
                     if (!navigator.serviceWorker.controller) {
-                      toastActions.showToast({
-                        message: '{$ cachingComplete $}',
-                      });
+                      if (toastActions) {
+                        toastActions.showToast({
+                          message: '{$ cachingComplete $}',
+                        });
+                      }
                     }
                     break;
                   case 'redundant':


### PR DESCRIPTION
in the same file we test if `toastActions` is defined:

```
if (toastActions) {
          toastActions.showToast({
            message: '{$ newVersionAvailable $}',
            action: {
              title: '{$ refresh $}',
              callback: tapHandler,
            },
            duration: 0,
          });
        }
```

but here no 🤔 Adding the test to fix a FF issue