### PR TITLE
feat(tickets): add information about tickets

### DIFF
--- a/data/firebase-data.json
+++ b/data/firebase-data.json
@@ -241,6 +241,43 @@
       "title": "Core Team"
     }
   ],
-  "tickets": {},
+  "tickets": [{
+    "available" : true,
+    "currency" : "€",
+    "starts" : "04 Avril",
+    "ends" : "08 Novembre",
+    "inDemand" : false,
+    "info" : "50 premieres places",
+    "name" : "BlindBirds",
+    "price" : 40,
+    "regular" : true,
+    "soldOut" : false,
+    "url" : "https://www.billetweb.fr/devfest-toulouse-2018"
+  }, {
+    "available" : false,
+    "currency" : "€",
+    "starts" : "04 Avril",
+    "ends" : "08 Novembre",
+    "inDemand" : false,
+    "info" : "70 premieres places",
+    "name" : "EarlyBirds",
+    "price" : 60,
+    "regular" : true,
+    "soldOut" : false,
+    "url" : "https://www.billetweb.fr/devfest-toulouse-2018"
+  }, {
+    "available" : false,
+    "currency" : "€",
+    "starts" : "04 Avril",
+    "ends" : "08 Novembre",
+    "inDemand" : false,
+    "info" : "250 premieres places",
+    "name" : "Normal",
+    "price" : 80,
+    "regular" : true,
+    "soldOut" : false,
+    "url" : "https://www.billetweb.fr/devfest-toulouse-2018",
+    "primary" : true
+  }],
   "videos": []
 }

--- a/data/resources.json
+++ b/data/resources.json
@@ -90,10 +90,10 @@
   },
   "ticketsBlock": {
     "title": "Tickets",
-    "ticketsDetails": "Tickets grant access to all conference sections, coffee breaks, lunch and party. Accommodation is NOT included in the ticket price.",
-    "soldOut": "You missed it!",
-    "notAvailableYet": "Not available yet",
-    "save": "Save ${discount}% today"
+    "ticketsDetails": "Votre billet vous donne accès à toutes les conférences, aux pauses café, et au repas. L'hébergement n'est PAS inclus dans ce prix.",
+    "soldOut": "Rupture de stock",
+    "notAvailableYet": "Pas encore disponible...",
+    "save": "Économisez ${discount}% !"
   },
   "partnersBlock": {
     "title": "Partners",

--- a/src/pages/home-page.html
+++ b/src/pages/home-page.html
@@ -160,7 +160,7 @@
     <about-block></about-block>
     <!--<speakers-block></speakers-block>-->
     <subscribe-block-shprink></subscribe-block-shprink>
-    <!--<tickets-block></tickets-block>-->
+    <tickets-block></tickets-block>
     <!--<gallery-block></gallery-block>-->
     <!--<about-organizer-block></about-organizer-block>-->
     <!--<featured-videos></featured-videos>-->


### PR DESCRIPTION
In this first version, only the `BlindBird` is activated. Modification on the database will allow to activate other type of tickets
This choice have been made to be coherent with billetweb interface

![image](https://user-images.githubusercontent.com/1970922/38287848-4d363dc8-37cd-11e8-92c6-70e5f2fd5036.png)


Closes #20